### PR TITLE
Remove rpi-update from installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A pre-compiled binary of OpenCV for the Raspberry Pi.   It is available in a ".d
   ```
 sudo apt-get update
 sudo apt-get upgrade
-sudo rpi-update
   ```
 1) We need to install some packages that allow OpenCV to process images:
   ```


### PR DESCRIPTION
Not many know this, ant rpi-update has been around in many tutorials on the internet. But it's probably a dangerous tool, if you don't know exactly what you, since it will install the latest, untested, unstable firmware! In the worst case, the Pi would not boot anymore afterwards.

Quoting its GitHub README:

> Even on Raspbian you should only use this with a good reason.
> This gets you the latest bleeding edge kernel/firmware. There is always the possibility of regressions.
> Bug fixes and improvements will eventually make their way into new Raspbian releases and apt-get when they are considered sufficiently well tested.

https://github.com/Hexxeh/rpi-update

In this case there's simply no need to run the command.